### PR TITLE
resolves #11 - 이슈에 대한 뉴스리스트와 이슈 상세 조회 구현

### DIFF
--- a/src/main/java/news_recommend/news/config/SecurityConfig.java
+++ b/src/main/java/news_recommend/news/config/SecurityConfig.java
@@ -29,8 +29,15 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/users/signup", "/api/users/login", "/api/auth/validate", "/error").permitAll() // 인증 없이 허용
-                        .anyRequest().authenticated() // 그 외는 인증 필요
+                        .requestMatchers(
+                                "/api/users/signup",
+                                "/api/users/login",
+                                "/api/auth/validate",
+                                "/api/issues/*/news",
+                                "/api/issues/analyze", // ✅ 이 경로는 인증 없이 허용(임의)
+                                "/error"
+                        ).permitAll()
+                        .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
                 .build();

--- a/src/main/java/news_recommend/news/issue/Issue.java
+++ b/src/main/java/news_recommend/news/issue/Issue.java
@@ -7,6 +7,7 @@ public class Issue {
     private String issueName;
     private String category;
     private String emotion;
+    private String title;
 
 
     public Issue() {}
@@ -41,6 +42,10 @@ public class Issue {
         return emotion;
     }
 
+    public String getTitle() {
+        return title;
+    }
+
     public void setIssueId(Long issueId) {
         this.issueId = issueId;
     }
@@ -55,5 +60,9 @@ public class Issue {
 
     public void setEmotion(String emotion) {
         this.emotion = emotion;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
     }
 }

--- a/src/main/java/news_recommend/news/issue/IssueController.java
+++ b/src/main/java/news_recommend/news/issue/IssueController.java
@@ -1,30 +1,42 @@
 package news_recommend.news.issue;
 
-
+import news_recommend.news.issue.dto.IssueDetailResponse;
+import news_recommend.news.issue.dto.RawNews;
+import news_recommend.news.issue.service.NewsFetchService;
+import news_recommend.news.llm.LLMService;
 import news_recommend.news.utils.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/issues")
 public class IssueController {
 
     private final IssueService issueService;
+    private final NewsFetchService newsFetchService;
+    private final LLMService llmService;
 
-    public IssueController(final IssueService issueService){
+    public IssueController(
+            final IssueService issueService,
+            final NewsFetchService newsFetchService,
+            final LLMService llmService
+    ) {
         this.issueService = issueService;
+        this.newsFetchService = newsFetchService;
+        this.llmService = llmService;
     }
 
-
     @GetMapping
-    public ResponseEntity<List<Issue>> getIssues() { return ResponseEntity.ok(issueService.findIssues());
+    public ResponseEntity<List<Issue>> getIssues() {
+        return ResponseEntity.ok(issueService.findIssues());
     }
 
     @PostMapping
     public ResponseEntity<Issue> createIssue(@RequestBody Issue issue) {
-
         return ResponseEntity.ok(issueService.save(issue));
     }
 
@@ -59,5 +71,69 @@ public class IssueController {
     }
     // 카테고리별 이슈 리스트 코드 추가 끝
 
+    // 네이버 뉴스 API로 이슈명에 해당하는 뉴스 조회
+    @GetMapping("/{issueName}/news")
+    public ResponseEntity<List<RawNews>> getIssueNews(@PathVariable String issueName) {
+        List<RawNews> news = newsFetchService.fetch(issueName);
+        return ResponseEntity.ok(news);
+    }
 
+    // 북마크를 위한 db저장용?
+    @GetMapping("/{id}/detail")
+    public ResponseEntity<IssueDetailResponse> getIssueDetail(@PathVariable Long id) {
+        Optional<Issue> issueOpt = issueService.findById(id);
+        if (issueOpt.isEmpty()) return ResponseEntity.notFound().build();
+
+        Issue issue = issueOpt.get();
+        List<RawNews> newsList = newsFetchService.fetch(issue.getTitle());
+
+        List<IssueDetailResponse.NewsWithScore> newsWithScores = new ArrayList<>();
+        for (RawNews news : newsList) {
+            int score = llmService.analyzeSentimentScore(news.getTitle(), news.getDescription());
+            newsWithScores.add(new IssueDetailResponse.NewsWithScore(
+                    news.getTitle(),
+                    news.getLink(),
+                    news.getDescription(),
+                    news.getPubDate(),
+                    score
+            ));
+        }
+
+        String category = llmService.classifyCategory(issue.getTitle(), newsList);
+        boolean bookmarked = false;
+
+        IssueDetailResponse response = new IssueDetailResponse(
+                issue.getTitle(), category, newsWithScores, bookmarked
+        );
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/analyze")
+    public ResponseEntity<IssueDetailResponse> analyzeIssueByQuery(@RequestParam String query) {
+        List<RawNews> newsList = newsFetchService.fetch(query);
+
+        List<IssueDetailResponse.NewsWithScore> newsWithScores = new ArrayList<>();
+        for (RawNews news : newsList) {
+            int score = llmService.analyzeSentimentScore(news.getTitle(), news.getDescription());
+            newsWithScores.add(new IssueDetailResponse.NewsWithScore(
+                    news.getTitle(),
+                    news.getLink(),
+                    news.getDescription(),
+                    news.getPubDate(),
+                    score
+            ));
+        }
+
+        String category = llmService.classifyCategory(query, newsList);
+
+        IssueDetailResponse response = new IssueDetailResponse(
+                query,
+                category,
+                newsWithScores,
+                false // 북마크 여부 (임시)
+        );
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/news_recommend/news/issue/dto/IssueDetailResponse.java
+++ b/src/main/java/news_recommend/news/issue/dto/IssueDetailResponse.java
@@ -1,0 +1,48 @@
+package news_recommend.news.issue.dto;
+
+import java.util.List;
+
+public class IssueDetailResponse {
+
+    private String issueName;
+    private String category;
+    private List<NewsWithScore> newsList; // RawNews -> NewsWithScore
+    private boolean isBookmarked;
+
+    public IssueDetailResponse(String issueName, String category, List<NewsWithScore> newsList, boolean isBookmarked) {
+        this.issueName = issueName;
+        this.category = category;
+        this.newsList = newsList;
+        this.isBookmarked = isBookmarked;
+    }
+
+    // 내부 정적 클래스 정의
+    public static class NewsWithScore {
+        private String title;
+        private String link;
+        private String description;
+        private String pubDate;
+        private int sentimentScore;
+
+        public NewsWithScore(String title, String link, String description, String pubDate, int sentimentScore) {
+            this.title = title;
+            this.link = link;
+            this.description = description;
+            this.pubDate = pubDate;
+            this.sentimentScore = sentimentScore;
+        }
+
+        // Getters
+        public String getTitle() { return title; }
+        public String getLink() { return link; }
+        public String getDescription() { return description; }
+        public String getPubDate() { return pubDate; }
+        public int getSentimentScore() { return sentimentScore; }
+    }
+
+    // Getters
+    public String getIssueName() { return issueName; }
+    public String getCategory() { return category; }
+    public List<NewsWithScore> getNewsList() { return newsList; }
+    public boolean isBookmarked() { return isBookmarked; }
+}

--- a/src/main/java/news_recommend/news/issue/dto/IssuePreviewResponse.java
+++ b/src/main/java/news_recommend/news/issue/dto/IssuePreviewResponse.java
@@ -1,0 +1,28 @@
+package news_recommend.news.issue.dto;
+
+import java.util.List;
+
+public class IssuePreviewResponse {
+    private String issueName;
+    private String category;
+    private List<RawNews> newsList;
+
+    public IssuePreviewResponse(String issueName, String category, List<RawNews> newsList) {
+        this.issueName = issueName;
+        this.category = category;
+        this.newsList = newsList;
+    }
+
+    public String getIssueName() {
+        return issueName;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+
+    public List<RawNews> getNewsList() {
+        return newsList;
+    }
+}

--- a/src/main/java/news_recommend/news/issue/dto/RawNews.java
+++ b/src/main/java/news_recommend/news/issue/dto/RawNews.java
@@ -1,0 +1,37 @@
+package news_recommend.news.issue.dto;
+
+public class RawNews {
+
+    private String title;
+    private String link;
+    private String description;
+    private String pubDate;
+
+    // 감정 점수 추가 (1~100)
+    private Integer sentimentScore;
+
+    public RawNews() {
+    }
+
+    public RawNews(String title, String link, String description, String pubDate) {
+        this.title = title;
+        this.link = link;
+        this.description = description;
+        this.pubDate = pubDate;
+    }
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    public String getLink() { return link; }
+    public void setLink(String link) { this.link = link; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getPubDate() { return pubDate; }
+    public void setPubDate(String pubDate) { this.pubDate = pubDate; }
+
+    public Integer getSentimentScore() { return sentimentScore; }
+    public void setSentimentScore(Integer sentimentScore) { this.sentimentScore = sentimentScore; }
+}

--- a/src/main/java/news_recommend/news/issue/service/NewsFetchService.java
+++ b/src/main/java/news_recommend/news/issue/service/NewsFetchService.java
@@ -1,0 +1,59 @@
+package news_recommend.news.issue.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import news_recommend.news.issue.dto.RawNews;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.*;
+
+@Service
+public class NewsFetchService {
+
+    @Value("${naver.client.id}")
+    private String clientId;
+
+    @Value("${naver.client.secret}")
+    private String clientSecret;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public List<RawNews> fetch(String keyword) {
+        String url = "https://openapi.naver.com/v1/search/news.json";
+
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(url)
+                .queryParam("query", keyword)
+                .queryParam("display", 5)
+                .queryParam("sort", "date");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-Naver-Client-Id", clientId);
+        headers.set("X-Naver-Client-Secret", clientSecret);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+        ResponseEntity<String> response = restTemplate.exchange(
+                builder.toUriString(), HttpMethod.GET, entity, String.class);
+
+        List<RawNews> results = new ArrayList<>();
+
+        try {
+            JsonNode root = objectMapper.readTree(response.getBody());
+            for (JsonNode item : root.path("items")) {
+                RawNews news = new RawNews();
+                news.setTitle(item.path("title").asText().replaceAll("<[^>]*>", ""));
+                news.setLink(item.path("originallink").asText());
+                news.setDescription(item.path("description").asText().replaceAll("<[^>]*>", ""));
+                news.setPubDate(item.path("pubDate").asText());
+                results.add(news);
+            }
+            return results;
+        } catch (Exception e) {
+            throw new RuntimeException("네이버 뉴스 API 응답 파싱 실패", e);
+        }
+    }
+}

--- a/src/main/java/news_recommend/news/llm/LLMService.java
+++ b/src/main/java/news_recommend/news/llm/LLMService.java
@@ -1,0 +1,80 @@
+package news_recommend.news.llm;
+
+import news_recommend.news.issue.dto.RawNews;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+public class LLMService {
+
+    @Value("${openai.api.key}")
+    private String apiKey;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private static final String API_URL = "https://api.openai.com/v1/chat/completions";
+
+    // 기존 제목 기반 카테고리 분류
+    public String classifyCategory(List<String> titles) {
+        String prompt = "다음 뉴스 제목을 보고 15개 카테고리 중 하나로 분류해줘. 카테고리는 정치, 경제, 사회, 사건/사고, IT/과학, 자동차, 국제, 교육, 문화, 여행/레저, 연예, 환경, 부동산, 스포츠, 생활/건강이야.\n\n";
+        for (String title : titles) {
+            prompt += "- " + title + "\n";
+        }
+        prompt += "\n이 뉴스들의 공통 카테고리는? (정확한 하나만 반환해줘)";
+        return callOpenAI(prompt);
+    }
+
+    // ✅ 뉴스 본문 기반 카테고리 분류 (query + 뉴스 리스트 사용)
+    public String classifyCategory(String query, List<RawNews> newsList) {
+        String prompt = "다음 뉴스들을 참고하여 '" + query + "' 이슈의 카테고리를 다음 중 하나로 분류해줘:\n" +
+                "정치, 경제, 사회, 사건/사고, IT/과학, 자동차, 국제, 교육, 문화, 여행/레저, 연예, 환경, 부동산, 스포츠, 생활/건강\n\n" +
+                newsList.stream()
+                        .map(n -> "제목: " + n.getTitle() + "\n내용: " + n.getDescription())
+                        .collect(Collectors.joining("\n\n")) +
+                "\n\n위 뉴스들의 공통 카테고리는? 정확하게 하나만 답해줘.";
+
+        return callOpenAI(prompt);
+    }
+
+    // ✅ 뉴스 1건에 대해 1~100 감정 점수 반환
+    public int analyzeSentimentScore(String title, String description) {
+        String prompt = "다음 뉴스의 제목과 내용을 바탕으로 감정을 분석해서 1~100 사이의 점수로 나타내줘.\n" +
+                "1에 가까우면 부정, 50은 중립, 100에 가까우면 긍정이야.\n" +
+                "숫자만 반환해줘.\n\n" +
+                "제목: " + title + "\n내용: " + description;
+
+        String result = callOpenAI(prompt);
+        try {
+            return Integer.parseInt(result.replaceAll("[^\\d]", ""));
+        } catch (NumberFormatException e) {
+            return 50; // 실패 시 중립 처리
+        }
+    }
+
+    // GPT API 호출 공통 메서드
+    private String callOpenAI(String prompt) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("model", "gpt-3.5-turbo");
+        body.put("messages", List.of(Map.of("role", "user", "content", prompt)));
+        body.put("temperature", 0.2);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(apiKey);
+
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
+
+        try {
+            ResponseEntity<Map> response = restTemplate.postForEntity(API_URL, request, Map.class);
+            Map<String, Object> choice = ((List<Map<String, Object>>) response.getBody().get("choices")).get(0);
+            Map<String, Object> message = (Map<String, Object>) choice.get("message");
+            return message.get("content").toString().trim();
+        } catch (Exception e) {
+            throw new RuntimeException("OpenAI 호출 중 오류 발생: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣이슈 번호

> #11

## 📝작업 내용

> 
- 네이버 검색 api를 사용해 뉴스리스트 조회 구현
- llm으로 감정분석 기능과 카테고리 분류 기능을 구현
- 이슈 이름, 감정 분석, 뉴스 리스트, 카테고리, 북마크 여부가 포함된 이슈 상세 조회 구현
<!-- 어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제 -->

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족하는지 확인하세요.

<!-- - [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트). -->
